### PR TITLE
Fixes to python3-minimal and r-tidyverse

### DIFF
--- a/python3-minimal/Dockerfile
+++ b/python3-minimal/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && \
     apt-get install -yq --no-install-recommends \
     wget \
     bzip2 \
+    build-essential \
     ca-certificates \
     sudo \
     locales \

--- a/python3-minimal/Dockerfile
+++ b/python3-minimal/Dockerfile
@@ -13,8 +13,10 @@ RUN apt-get update && \
     apt-get install -yq --no-install-recommends \
     wget \
     bzip2 \
-    build-essential \
     ca-certificates \
+    gcc \
+    g++ \
+    make \
     sudo \
     locales \
     fonts-liberation \

--- a/r-tidyverse/Dockerfile
+++ b/r-tidyverse/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update \
     # Other basic R stuff breaks without the Olson database
     tzdata \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /var/log/dpkg.log
+    && rm -f /var/log/dpkg.log
 
 # Install R packages
 # For R, the Anaconda "official" packages seem better than conda-forge

--- a/r-tidyverse/Dockerfile
+++ b/r-tidyverse/Dockerfile
@@ -5,8 +5,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-#FROM gigantum/python3-minimal:latest
-FROM gigantum/python3-minimal:df4dbd9a-2018-06-27
+FROM gigantum/python3-minimal:latest
 LABEL maintainer="Gigantum <hello@gigantum.io>"
 
 # This is needed for tzdata to proceed, but should probably be set generally

--- a/r-tidyverse/Dockerfile
+++ b/r-tidyverse/Dockerfile
@@ -5,7 +5,8 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-FROM gigantum/python3-minimal:latest
+#FROM gigantum/python3-minimal:latest
+FROM gigantum/python3-minimal:df4dbd9a-2018-06-27
 LABEL maintainer="Gigantum <hello@gigantum.io>"
 
 # This is needed for tzdata to proceed, but should probably be set generally


### PR DESCRIPTION
Add build-essential to python3-minimal.  This is needed by all pip packages that invoke a compiler.

Don't delete package list in r-tidyverse.  This makes fixes apt (which was broken).

Dav should resolve this PR and handle the tooling in the environment.