### PR TITLE
hotfix correct pyyaml version

### DIFF
--- a/python3-data-science/python3-data-science_r10.yaml
+++ b/python3-data-science/python3-data-science_r10.yaml
@@ -37,7 +37,7 @@ package_managers:
   - plotly=4.4*
   - plotly-orca=1.2*
   - pywavelets=1.1*
-  - pyyaml=5.1*
+  - pyyaml=5.2*
   - scikit-image=0.16*
   - scikit-learn=0.22*
   - scipy=1.3*


### PR DESCRIPTION
Pretty self-explanatory. Chaning pyyaml version in the yaml description for python3-data-science r10 to reflect what's in the Dockerfile / built image.